### PR TITLE
Add WHITELIST parameter to CRITIQUE-ASDF-SYSTEM

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ To get some advices, use [`critique-asdf-system`][c8a0] function. Difference bet
 this function and `LISP-CRITIC:CRITIQUE-FILE` function is that the latter
 outputs all forms from the file even if there is no any advices.
 
+[`critique-asdf-system`][c8a0] has `IGNORE` and `WHITELIST` keyword parameters. The
+arguments can be a list of strings. Each string should be a code
+shown in the square brackets in the critique output. `IGNORE` arguments will
+be ignored, while `WHITELIST` arguments will be the only results. You can
+only supply either `IGNORE` or `WHITELIST`, not both.
+
+```lisp
+(critique-asdf-system :lisp-critic :ignore '("let*-single"))
+(critique-asdf-system :lisp-critic :whitelist '("let*-single" "needless-shiftf"))
+```
 Also, [`critique-asdf-system`][c8a0] returns a number of found problems which is useful
 for `CI` pipelines. For example, `lisp-critic` script uses this number to report
 that the unix command was failed:
@@ -86,6 +96,34 @@ lisp-critic reblocks-text-editor
 You can ignore all `let*-single` warnings by adding `--ignore 'let*-single'`
 command line option or put a special comment before the top-level form:
 
+You can ignore all `let*-single` warnings by adding `--ignore 'let*-single'`
+
+```bash
+lisp-critic --ignore 'let*-single' lisp-critic
+```
+or ignore all `if-no-else` and `needless-shiftf` warnings by adding
+
+```bash
+lisp-critic --ignore 'if-no-else,needless-shiftf' lisp-critic
+```
+in the command line. Alternatively you can use the short version `-i`
+instead of `--ignore`.
+
+You can whitelist `let*-single` warnings by adding `--whitelist 'let*-single'`
+
+```bash
+lisp-critic --whitelist 'let*-single' lisp-critic
+```
+or whitelist `if-no-else` and `needless-shiftf` warnings by adding
+
+```bash
+lisp-critic --whitelist 'if-no-else,needless-shiftf' lisp-critic
+```
+in the command line. Alternatively you can use the short version `-w`
+instead of `--whitelist`.
+
+To ignore a top-level-form, you can put a special comment before:
+
 ```lisp
 ;; ignore-critiques: let*-single
 (defun remove-html-tags (html-string)
@@ -100,7 +138,7 @@ Such comment can enumerate a multiple comma-separated critiques names.
 
 <a id="x-2840ANTS-CRITIC-3ACRITIQUE-ASDF-SYSTEM-20FUNCTION-29"></a>
 
-### [function](6bb1) `40ants-critic:critique-asdf-system` name &key (out \*standard-output\*) (ignore nil)
+### [function](411f) `40ants-critic:critique-asdf-system` name &key (out \*standard-output\*) (ignore nil) (whitelist nil)
 
 Outputs advices on how given `ASDF` system can be improved.
 This function analyzes all lisp files of the given system and
@@ -110,6 +148,11 @@ outputs advices on how code might be improved.
 
 `IGNORE` argument can be a list of string. Each string should be a code
 shown in the square brackets in the critique output.
+
+`WHITELIST` argument can be a list of string. Each string should be a code
+shown in the square brackets in the critique output.
+
+Only `IGNORE` or `WHITELIST` can be used. Not both at the same time.
 
 `OUT` argument is optional. It should be an output stream to write
 advices to.
@@ -121,7 +164,7 @@ Result of the function is number of found problems.
 [c8a0]: https://40ants.com/40ants-critic/#x-2840ANTS-CRITIC-3ACRITIQUE-ASDF-SYSTEM-20FUNCTION-29
 [240b]: https://40ants.com/ci/#x-2840ANTS-CI-3A-3A-40CRITIC-2040ANTS-DOC-2FLOCATIVES-3ASECTION-29
 [4062]: https://github.com/40ants/40ants-critic
-[6bb1]: https://github.com/40ants/40ants-critic/blob/52997926b6dd9d8d8e9c366c00d6777327dce519/src/critic.lisp#L139
+[411f]: https://github.com/40ants/40ants-critic/blob/21f6afdf43bf1c7f541d113d55917e1f7b4e4b02/src/critic.lisp#L152
 [795a]: https://github.com/roswell/roswell
 [2a0d]: https://ultralisp.org
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ lisp-critic --whitelist 'if-no-else,needless-shiftf' lisp-critic
 in the command line. Alternatively you can use the short version `-w`
 instead of `--whitelist`.
 
+```bash
+lisp-critic -w 'let*-single' lisp-critic
+lisp-critic -w 'if-no-else,needless-shiftf' lisp-critic
+```
 To ignore a top-level-form, you can put a special comment before:
 
 ```lisp
@@ -138,7 +142,7 @@ Such comment can enumerate a multiple comma-separated critiques names.
 
 <a id="x-2840ANTS-CRITIC-3ACRITIQUE-ASDF-SYSTEM-20FUNCTION-29"></a>
 
-### [function](fde9) `40ants-critic:critique-asdf-system` name &key (out \*standard-output\*) (ignore nil) (whitelist nil)
+### [function](56e1) `40ants-critic:critique-asdf-system` name &key (out \*standard-output\*) (ignore nil) (whitelist nil)
 
 Outputs advices on how given `ASDF` system can be improved.
 This function analyzes all lisp files of the given system and
@@ -164,7 +168,7 @@ Result of the function is number of found problems.
 [c8a0]: https://40ants.com/40ants-critic/#x-2840ANTS-CRITIC-3ACRITIQUE-ASDF-SYSTEM-20FUNCTION-29
 [240b]: https://40ants.com/ci/#x-2840ANTS-CI-3A-3A-40CRITIC-2040ANTS-DOC-2FLOCATIVES-3ASECTION-29
 [4062]: https://github.com/40ants/40ants-critic
-[fde9]: https://github.com/40ants/40ants-critic/blob/69968e06d98e116158c0d4a7f350ef2a23a282bf/src/critic.lisp#L156
+[56e1]: https://github.com/40ants/40ants-critic/blob/6bc9d2287e1a0de62d577730a1f074e9e78ceb00/src/critic.lisp#L148
 [795a]: https://github.com/roswell/roswell
 [2a0d]: https://ultralisp.org
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ To get some advices, use [`critique-asdf-system`][c8a0] function. Difference bet
 this function and `LISP-CRITIC:CRITIQUE-FILE` function is that the latter
 outputs all forms from the file even if there is no any advices.
 
+[`critique-asdf-system`][c8a0] has `IGNORE` and `WHITELIST` keyword parameters. The
+arguments can be a list of strings. Each string should be a code
+shown in the square brackets in the critique output. `IGNORE` arguments will
+be ignored, while `WHITELIST` arguments will be the only results. You can
+only supply either `IGNORE` or `WHITELIST`, not both.
+
+```lisp
+(critique-asdf-system :lisp-critic :ignore '("let*-single"))
+(critique-asdf-system :lisp-critic :whitelist '("let*-single" "needless-shiftf"))
+```
 Also, [`critique-asdf-system`][c8a0] returns a number of found problems which is useful
 for `CI` pipelines. For example, `lisp-critic` script uses this number to report
 that the unix command was failed:
@@ -86,6 +96,34 @@ lisp-critic reblocks-text-editor
 You can ignore all `let*-single` warnings by adding `--ignore 'let*-single'`
 command line option or put a special comment before the top-level form:
 
+You can ignore all `let*-single` warnings by adding `--ignore 'let*-single'`
+
+```bash
+lisp-critic --ignore 'let*-single' lisp-critic
+```
+or ignore all `if-no-else` and `needless-shiftf` warnings by adding
+
+```bash
+lisp-critic --ignore 'if-no-else,needless-shiftf' lisp-critic
+```
+in the command line. Alternatively you can use the short version `-i`
+instead of `--ignore`.
+
+You can whitelist `let*-single` warnings by adding `--whitelist 'let*-single'`
+
+```bash
+lisp-critic --whitelist 'let*-single' lisp-critic
+```
+or whitelist `if-no-else` and `needless-shiftf` warnings by adding
+
+```bash
+lisp-critic --whitelist 'if-no-else,needless-shiftf' lisp-critic
+```
+in the command line. Alternatively you can use the short version `-w`
+instead of `--whitelist`.
+
+To ignore a top-level-form, you can put a special comment before:
+
 ```lisp
 ;; ignore-critiques: let*-single
 (defun remove-html-tags (html-string)
@@ -100,7 +138,7 @@ Such comment can enumerate a multiple comma-separated critiques names.
 
 <a id="x-2840ANTS-CRITIC-3ACRITIQUE-ASDF-SYSTEM-20FUNCTION-29"></a>
 
-### [function](0d7f) `40ants-critic:critique-asdf-system` name &key (out \*standard-output\*) (ignore nil)
+### [function](fde9) `40ants-critic:critique-asdf-system` name &key (out \*standard-output\*) (ignore nil) (whitelist nil)
 
 Outputs advices on how given `ASDF` system can be improved.
 This function analyzes all lisp files of the given system and
@@ -110,6 +148,11 @@ outputs advices on how code might be improved.
 
 `IGNORE` argument can be a list of string. Each string should be a code
 shown in the square brackets in the critique output.
+
+`WHITELIST` argument can be a list of string. Each string should be a code
+shown in the square brackets in the critique output.
+
+Only `IGNORE` or `WHITELIST` can be used. Not both at the same time.
 
 `OUT` argument is optional. It should be an output stream to write
 advices to.
@@ -121,7 +164,7 @@ Result of the function is number of found problems.
 [c8a0]: https://40ants.com/40ants-critic/#x-2840ANTS-CRITIC-3ACRITIQUE-ASDF-SYSTEM-20FUNCTION-29
 [240b]: https://40ants.com/ci/#x-2840ANTS-CI-3A-3A-40CRITIC-2040ANTS-DOC-2FLOCATIVES-3ASECTION-29
 [4062]: https://github.com/40ants/40ants-critic
-[0d7f]: https://github.com/40ants/40ants-critic/blob/0852634ebcbf03f529a16d242e88540f32059fc5/src/critic.lisp#L143
+[fde9]: https://github.com/40ants/40ants-critic/blob/69968e06d98e116158c0d4a7f350ef2a23a282bf/src/critic.lisp#L156
 [795a]: https://github.com/roswell/roswell
 [2a0d]: https://ultralisp.org
 

--- a/src/critic.lisp
+++ b/src/critic.lisp
@@ -139,19 +139,11 @@
     
     (values problems-count)))
 
-
-(defparameter pattern-names
-  (mapcar #'(lambda (rule) (string-downcase (symbol-name rule)))
-          (lisp-critic:get-pattern-names))
-  "List of all LISP-CRITIC pattern names as lowercase strings")
-
 (defun get-blacklist (whitelist)
   "Returns list of all LISP-CRITIC patterns, excluding WHITELIST arguments."
-  (let ((blacklist nil))
-    (dolist (pattern pattern-names)
-      (unless (member pattern whitelist :test #'string=)
-        (push pattern blacklist)))
-    blacklist))
+  (loop for pattern in (lisp-critic:get-pattern-names)
+        unless (member pattern whitelist :test #'string-equal)
+          collect (string-downcase pattern)))
 
 (defun critique-asdf-system (name &key
                                     (out *standard-output*)

--- a/src/critic.lisp
+++ b/src/critic.lisp
@@ -267,6 +267,17 @@ To learn more about using it as a part of the GitHub workflow, read
    this function and LISP-CRITIC:CRITIQUE-FILE function is that the latter
    outputs all forms from the file even if there is no any advices.
 
+   CRITIQUE-ASDF-SYSTEM has IGNORE and WHITELIST keyword parameters. The
+   arguments can be a list of strings. Each string should be a code
+   shown in the square brackets in the critique output. IGNORE arguments will
+   be ignored, while WHITELIST arguments will be the only results. You can
+   only supply either IGNORE or WHITELIST, not both.
+
+   ```lisp
+   (critique-asdf-system :lisp-critic :ignore '(\"let*-single\"))
+   (critique-asdf-system :lisp-critic :whitelist '(\"let*-single\" \"needless-shiftf\"))
+   ```
+
    Also, CRITIQUE-ASDF-SYSTEM returns a number of found problems which is useful
    for CI pipelines. For example, `lisp-critic` script uses this number to report
    that the unix command was failed:
@@ -291,6 +302,38 @@ To learn more about using it as a part of the GitHub workflow, read
 
    You can ignore all `let*-single` warnings by adding `--ignore 'let*-single'`
    command line option or put a special comment before the top-level form:
+
+   You can ignore all `let*-single` warnings by adding `--ignore 'let*-single'`
+
+   ```bash
+   lisp-critic --ignore 'let*-single' lisp-critic
+   ```
+
+   or ignore all `if-no-else` and `needless-shiftf` warnings by adding
+
+   ```bash
+   lisp-critic --ignore 'if-no-else,needless-shiftf' lisp-critic
+   ```
+
+   in the command line. Alternatively you can use the short version `-i`
+   instead of `--ignore`.
+
+   You can whitelist `let*-single` warnings by adding `--whitelist 'let*-single'`
+
+   ```bash
+   lisp-critic --whitelist 'let*-single' lisp-critic
+   ```
+
+   or whitelist `if-no-else` and `needless-shiftf` warnings by adding
+
+   ```bash
+   lisp-critic --whitelist 'if-no-else,needless-shiftf' lisp-critic
+   ```
+
+   in the command line. Alternatively you can use the short version `-w`
+   instead of `--whitelist`.
+
+   To ignore a top-level-form, you can put a special comment before:
 
    ```lisp
    ;; ignore-critiques: let*-single

--- a/src/critic.lisp
+++ b/src/critic.lisp
@@ -329,6 +329,11 @@ To learn more about using it as a part of the GitHub workflow, read
    in the command line. Alternatively you can use the short version `-w`
    instead of `--whitelist`.
 
+   ```bash
+   lisp-critic -w 'let*-single' lisp-critic
+   lisp-critic -w 'if-no-else,needless-shiftf' lisp-critic
+   ```
+
    To ignore a top-level-form, you can put a special comment before:
 
    ```lisp

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -15,11 +15,16 @@
 
 (defmain (main :program-name "lisp-critic")
     ((ignore "Comma-separated list of codes to ignore.")
+     (whitelist "Comma-separated list of codes to whitelist.")
      asdf-system)
   (let* ((ignore (when ignore
                    (split-by-comma ignore)))
-         (num-problems (40ants-critic:critique-asdf-system asdf-system
-                                                           :ignore ignore)))
+         (whitelist (when whitelist
+                      (split-by-comma whitelist)))
+         (num-problems (40ants-critic:critique-asdf-system
+                        asdf-system
+                        :ignore ignore
+                        :whitelist whitelist)))
     (unless (zerop num-problems)
       (format t "~2&Total: ~A problem~:P~%"
               num-problems))


### PR DESCRIPTION
- `WHITELIST` syntax is equivalent to ignore, but only these patterns are shown, and all others ignored
- Either `IGNORE` or `WHITELIST` parameter can be supplied, not both
- Added parameter `PATTERN-NAMES` and function `GET-BLACKLIST` for `WHITELIST` processing
- Added `WHITELIST` arg to `DEFMAIN` `lisp-critic`
- Updated Docs for `WHITELIST` parameter and give more examples (also for command line)