### PR TITLE
Internal function asdf-system-files was fixed and now returns unique filenames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@
       "steps": [
         {
           "name": "Checkout Code",
-          "uses": "actions/checkout@v2"
+          "uses": "actions/checkout@v3"
         },
         {
           "name": "Grant All Perms to Make Cache Restoring Possible",
@@ -34,16 +34,16 @@
         {
           "name": "Get Current Month",
           "id": "current-month",
-          "run": "echo \"::set-output name=value::$(date -u \"+%Y-%m\")\"",
+          "run": "echo \"value=$(date -u \"+%Y-%m\")\" >> $GITHUB_OUTPUT",
           "shell": "bash"
         },
         {
           "name": "Cache Roswell Setup",
           "id": "cache",
-          "uses": "actions/cache@v2",
+          "uses": "actions/cache@v3",
           "with": {
-            "path": "qlfile\n                           qlfile.lock\n                           /usr/local/bin/ros\n                           ~/.cache/common-lisp/\n                           ~/.roswell\n                           /usr/local/etc/roswell\n                           .qlot",
-            "key": "${{ steps.current-month.outputs.value }}-${{ env.cache-name }}-ubuntu-latest-quicklisp-sbcl-bin-${{ hashFiles('qlfile.lock', '*.asd') }}"
+            "path": "qlfile\nqlfile.lock\n~/.cache/common-lisp/\n~/.roswell\n/usr/local/etc/roswell\n/usr/local/bin/ros\n/usr/local/Cellar/roswell\n.qlot",
+            "key": "a-${{ steps.current-month.outputs.value }}-${{ env.cache-name }}-ubuntu-latest-quicklisp-sbcl-bin-${{ hashFiles('qlfile.lock', '*.asd') }}"
           }
         },
         {
@@ -67,7 +67,7 @@
         },
         {
           "name": "Update Qlot",
-          "run": "qlot update || qlot update",
+          "run": "qlot update --no-deps",
           "shell": "bash"
         },
         {
@@ -92,7 +92,7 @@
       "steps": [
         {
           "name": "Checkout Code",
-          "uses": "actions/checkout@v2"
+          "uses": "actions/checkout@v3"
         },
         {
           "name": "Grant All Perms to Make Cache Restoring Possible",
@@ -102,16 +102,16 @@
         {
           "name": "Get Current Month",
           "id": "current-month",
-          "run": "echo \"::set-output name=value::$(date -u \"+%Y-%m\")\"",
+          "run": "echo \"value=$(date -u \"+%Y-%m\")\" >> $GITHUB_OUTPUT",
           "shell": "bash"
         },
         {
           "name": "Cache Roswell Setup",
           "id": "cache",
-          "uses": "actions/cache@v2",
+          "uses": "actions/cache@v3",
           "with": {
-            "path": "qlfile\n                           qlfile.lock\n                           /usr/local/bin/ros\n                           ~/.cache/common-lisp/\n                           ~/.roswell\n                           /usr/local/etc/roswell\n                           .qlot",
-            "key": "${{ steps.current-month.outputs.value }}-${{ env.cache-name }}-ubuntu-latest-quicklisp-sbcl-bin-${{ hashFiles('qlfile.lock', '*.asd') }}"
+            "path": "qlfile\nqlfile.lock\n~/.cache/common-lisp/\n~/.roswell\n/usr/local/etc/roswell\n/usr/local/bin/ros\n/usr/local/Cellar/roswell\n.qlot",
+            "key": "a-${{ steps.current-month.outputs.value }}-${{ env.cache-name }}-ubuntu-latest-quicklisp-sbcl-bin-${{ hashFiles('qlfile.lock', '*.asd') }}"
           }
         },
         {

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@
       "steps": [
         {
           "name": "Checkout Code",
-          "uses": "actions/checkout@v2"
+          "uses": "actions/checkout@v3"
         },
         {
           "name": "Grant All Perms to Make Cache Restoring Possible",
@@ -29,16 +29,16 @@
         {
           "name": "Get Current Month",
           "id": "current-month",
-          "run": "echo \"::set-output name=value::$(date -u \"+%Y-%m\")\"",
+          "run": "echo \"value=$(date -u \"+%Y-%m\")\" >> $GITHUB_OUTPUT",
           "shell": "bash"
         },
         {
           "name": "Cache Roswell Setup",
           "id": "cache",
-          "uses": "actions/cache@v2",
+          "uses": "actions/cache@v3",
           "with": {
-            "path": "qlfile\n                           qlfile.lock\n                           /usr/local/bin/ros\n                           ~/.cache/common-lisp/\n                           ~/.roswell\n                           /usr/local/etc/roswell\n                           .qlot",
-            "key": "${{ steps.current-month.outputs.value }}-${{ env.cache-name }}-ubuntu-latest-quicklisp-sbcl-bin-${{ hashFiles('qlfile.lock', '*.asd') }}"
+            "path": "qlfile\nqlfile.lock\n~/.cache/common-lisp/\n~/.roswell\n/usr/local/etc/roswell\n/usr/local/bin/ros\n/usr/local/Cellar/roswell\n.qlot",
+            "key": "a-${{ steps.current-month.outputs.value }}-${{ env.cache-name }}-ubuntu-latest-quicklisp-sbcl-bin-${{ hashFiles('qlfile.lock', '*.asd') }}"
           }
         },
         {

--- a/src/changelog.lisp
+++ b/src/changelog.lisp
@@ -6,7 +6,12 @@
 (in-package #:40ants-critic/changelog)
 
 
-(defchangelog ()
+(defchangelog (:ignore-words ("ASDF"))
+  (0.4.1 2022-11-10
+         "* Internal function asdf-system-files was fixed and now retursn unique filenames.
+
+            Previosly multiple copies of the same file returned for some package inferred ASDF systems
+            which produced multiple copies of critiqies and slowed down the shole process.")
   (0.4.0 2022-02-22
          "* Forms are printed in a more readable way now.
             Their symbols are printed relative to the file's package.")

--- a/src/critic.lisp
+++ b/src/critic.lisp
@@ -34,7 +34,8 @@
 
 
 (defun asdf-system-files (system)
-  (let ((primary-system-name (asdf:primary-system-name system)))
+  (let ((primary-system-name (asdf:primary-system-name system))
+        (results nil))
     (labels ((recurse (name)
                (let ((system (ensure-asdf-system name)))
                  (when (and system
@@ -49,7 +50,10 @@
                                  append (recurse component)))))))
       (loop for component in (recurse system)
             when (typep component 'asdf:cl-source-file)
-              collect (asdf:component-pathname component)))))
+              do (pushnew (asdf:component-pathname component)
+                          results
+                          :test #'equal))
+      (values results))))
 
 
 (defun critique-name (note)


### PR DESCRIPTION
Previosly multiple copies of the same file returned for some package inferred ASDF systems which produced multiple copies of critiqies and slowed down the shole process.