### PR TITLE
Fixed to work with latest Eclector

### DIFF
--- a/qlfile.lock
+++ b/qlfile.lock
@@ -1,8 +1,8 @@
 ("quicklisp" .
  (:class qlot/source/dist:source-dist
-  :initargs (:distribution "http://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
+  :initargs (:distribution "https://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
   :version "2023-10-21"))
 ("ultralisp" .
  (:class qlot/source/dist:source-dist
-  :initargs (:distribution "http://dist.ultralisp.org" :%version :latest)
-  :version "20240311030500"))
+  :initargs (:distribution "https://dist.ultralisp.org" :%version :latest)
+  :version "20240728204503"))

--- a/src/changelog.lisp
+++ b/src/changelog.lisp
@@ -7,6 +7,20 @@
 
 
 (defchangelog (:ignore-words ("ASDF"))
+  (0.5.0 2024-07-28
+         "* Fixed to work with latest Eclector.
+
+            Before this fix, with latest Eclector 40ants-critic didn't compile ending with this error:
+
+            ```
+            The generic function
+            #<STANDARD-GENERIC-FUNCTION ECLECTOR.PARSE-RESULT:MAKE-SKIPPED-INPUT-RESULT (2)>
+            takes 5 required arguments; was asked to find a method with
+            specializers (PARSE-CLIENT T T T)
+            ```
+
+            because the generic-function signature was changed.
+")
   (0.4.1 2022-11-10
          "* Internal function asdf-system-files was fixed and now retursn unique filenames.
 

--- a/src/forms-reader.lisp
+++ b/src/forms-reader.lisp
@@ -13,7 +13,7 @@
   result)
 
 (defmethod eclector.parse-result:make-skipped-input-result
-    ((client parse-client) (stream t) (reason t) (source t))
+    ((client parse-client) (stream t) (reason t) (children t) (source t))
   (list :reason reason :source source))
 
 


### PR DESCRIPTION
Before this fix, with latest Eclector 40ants-critic didn't compile ending with this error:

```
The generic function
takes 5 required arguments; was asked to find a method with
specializers (PARSE-CLIENT T T T)
```

because the generic-function signature was changed.